### PR TITLE
import neo in app.py

### DIFF
--- a/epitopepredict/app.py
+++ b/epitopepredict/app.py
@@ -23,7 +23,7 @@ import numpy as np
 import shutil
 import pandas as pd
 from collections import OrderedDict
-from epitopepredict import base, config, analysis, sequtils, plotting, dashboard
+from epitopepredict import base, config, analysis, sequtils, plotting, dashboard, neo
 
 defaultpath = os.getcwd()
 


### PR DESCRIPTION
When test this tool, it seems that the `neo` is not been imported:

```
epitopepredict -n -t

wrote config file default.conf
Traceback (most recent call last):
  File "/public/slst/home/wutao2/miniconda3/bin/epitopepredict", line 8, in <module>
    sys.exit(main())
  File "/public/slst/home/wutao2/miniconda3/lib/python3.8/site-packages/epitopepredict/app.py", line 497, in main
    neo.test_run()
NameError: name 'neo' is not defined
```